### PR TITLE
NOJIRA: add Vagrant definitions so the visible Nexus can be run in a VM.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# Vagrant directory
+.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,74 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+require 'yaml'
+
+ansible_vars = YAML.load_file('provisioning/vars.yml')
+
+app_name = ansible_vars["nodejs_app_name"]
+
+app_start_script = ansible_vars["nodejs_app_start_script"]
+
+app_directory = ansible_vars["nodejs_app_install_dir"]
+
+# Check for the existence of 'VM_HOST_TCP_PORT' or 'VM_GUEST_TCP_PORT'
+# environment variables. Otherwise if 'nodejs_app_tcp_port' is defined
+# in vars.yml then use that port. Failing that use defaults provided
+# in this file.
+host_tcp_port = ENV["VM_HOST_TCP_PORT"] || ansible_vars["nodejs_app_tcp_port"] || 8080
+guest_tcp_port = ENV["VM_GUEST_TCP_PORT"] || ansible_vars["nodejs_app_tcp_port"] || 8080
+
+# By default this VM will use 1 processor core and 1GB of RAM. The 'VM_CPUS' and
+# "VM_RAM" environment variables can be used to change that behaviour.
+cpus = ENV["VM_CPUS"] || 1
+ram = ENV["VM_RAM"] || 1048
+
+Vagrant.configure(2) do |config|
+
+  config.vm.box = "inclusivedesign/centos7"
+
+  # Your working directory will be synced to /home/vagrant/sync in the VM.
+  config.vm.synced_folder ".", "#{app_directory}"
+
+  # List additional directories to sync to the VM in your "Vagrantfile.local" file
+  # using the following format:
+  # config.vm.synced_folder "../path/on/your/host/os/your-project", "/home/vagrant/sync/your-project"
+
+  # Port forwarding takes place here. The 'guest' port is used inside the VM
+  # whereas the 'host' port is used by your host operating system.
+  config.vm.network "forwarded_port", guest: guest_tcp_port, host: host_tcp_port, protocol: "tcp",
+    auto_correct: true
+
+  # Port 19531 is needed so logs can be viewed using systemd-journal-gateway
+  config.vm.network "forwarded_port", guest: 19531, host: 19531, protocol: "tcp",
+    auto_correct: true
+
+  config.vm.hostname = app_name
+
+  config.vm.provider :virtualbox do |vm|
+    vm.customize ["modifyvm", :id, "--memory", ram]
+    vm.customize ["modifyvm", :id, "--cpus", cpus]
+  end
+
+  # The ansible-galaxy command assumes a git client is available in the VM, the
+  # inclusivedesign/centos7 Vagrant box includes one.
+  config.vm.provision "shell", inline: <<-SHELL
+    sudo ansible-galaxy install -fr #{app_directory}/provisioning/requirements.yml
+    sudo PYTHONUNBUFFERED=1 ansible-playbook #{app_directory}/provisioning/playbook.yml --tags="install,configure,deploy"
+  SHELL
+
+  # 'Vagrantfile.local' should be excluded from version control.
+  if File.exist? "Vagrantfile.local"
+    instance_eval File.read("Vagrantfile.local"), "Vagrantfile.local"
+  end
+
+  # http://serverfault.com/a/725051
+  if app_start_script.to_s.strip.length != 0
+    config.vm.provision "shell", inline: "sudo systemctl restart #{app_name}.service",
+      run: "always"
+  end
+
+  config.vm.provision "shell", inline: "sudo systemctl restart systemd-journal-gatewayd.service",
+    run: "always"
+
+end

--- a/provisioning/playbook.retry
+++ b/provisioning/playbook.retry
@@ -1,0 +1,1 @@
+localhost

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -1,0 +1,10 @@
+---
+- hosts: localhost
+  user: root
+
+  vars_files:
+    - vars.yml
+
+  roles:
+    - facts
+    - nodejs

--- a/provisioning/requirements.yml
+++ b/provisioning/requirements.yml
@@ -1,0 +1,5 @@
+- src: https://github.com/idi-ops/ansible-facts
+  name: facts
+
+- src: https://github.com/idi-ops/ansible-nodejs
+  name: nodejs

--- a/provisioning/vars.yml
+++ b/provisioning/vars.yml
@@ -1,0 +1,38 @@
+---
+# Please refer to https://github.com/idi-ops/ansible-nodejs/blob/master/defaults/main.yml
+# for additional documentation related to these variables
+
+# A hyphenated string representing the application's name.
+nodejs_app_name: nexus
+
+# A boolean stating whether the application's Git repository should be cloned or
+# not. An example scenario where you may want to set this to 'false' would be a
+# Vagrant project used for development where the application's source code might
+# already be present on local storage.
+nodejs_app_git_clone: false
+
+# The absolute file system path where either the application directory or the
+# Git working directory will be located.
+nodejs_app_install_dir: /home/vagrant/sync
+
+# A YAML list of commands that will be executed in order within the application's
+# Git working directory.
+nodejs_app_commands:
+  - npm install
+
+# The application script passed as an argument to the Node.js binary. If this
+# isn't set then the application won't start.
+nodejs_app_start_script: visibleNexus.js
+
+# Enabling this will manage the application using https://github.com/remy/nodemon
+# so that Node process is restarted when file system changes are detected. This
+# will only work if 'nodejs_app_start_script' is set.
+nodejs_app_dev_env: true
+
+# A YAML list of RPM packages that the application requires.
+# nodejs_app_rpm_packages:
+#   - nodejs-grunt-cli
+
+# A TCP port used by the application.
+# Example: 8080
+nodejs_app_tcp_port: 9081


### PR DESCRIPTION
This adds a Vagrantfile and the `/provisioning` directory to run visibleNexus in a VM; largely based off the VM definition from the Nexus itself, but does not pin the node version (uses the latest LTS release).